### PR TITLE
refactor: Update image paths for player and battle animations

### DIFF
--- a/frontend/app/components/BattleScene.tsx
+++ b/frontend/app/components/BattleScene.tsx
@@ -126,7 +126,7 @@ const BattleScreen: React.FC<BattleSceneProps> = ({ endBattle }) => {
     return (
       <div style={{ width: '80vw', height: '80vh', display: 'flex', justifyContent: 'center', alignItems: 'center', background: '#fff' }}>
         <Image
-          src="/images/pokeball.gif"
+          src="/Images/pokeball.gif"
           alt="Loading..."
           width={300}
           height={300}
@@ -164,7 +164,7 @@ const BattleScreen: React.FC<BattleSceneProps> = ({ endBattle }) => {
 
         <div className="absolute bottom-0 left-2">
           <Image
-            src={'/images/playerBackSprite.png'}
+            src={'/Images/playerBackSprite.png'}
             alt={'Player'}
             width={250}
             height={250}
@@ -218,7 +218,7 @@ const BattleScreen: React.FC<BattleSceneProps> = ({ endBattle }) => {
         {isThrowing && (
           <div className="absolute top-[30%] left-[80%]">
             <Image
-              src="/images/catching.gif"
+              src="/Images/catching.gif"
               alt="Catching Pokemon..."
               width={100}
               height={100}
@@ -230,7 +230,7 @@ const BattleScreen: React.FC<BattleSceneProps> = ({ endBattle }) => {
           <div className="absolute top-40 rigth-[2%]">
             <Image
               className='absolute right-[25%] top-[20%]'
-              src="/images/closePokeball.png"
+              src="/Images/closePokeball.png"
               alt="Caught!"
               width={150}
               height={200}
@@ -250,7 +250,7 @@ const BattleScreen: React.FC<BattleSceneProps> = ({ endBattle }) => {
         {catchStatus === 'escape' && (
           <div className="flex flex-col absolute top-40">
             <Image
-              src="/images/openPokeBall.png"
+              src="/Images/openPokeBall.png"
               alt="Escaped!"
               width={200}
               height={200}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -213,23 +213,23 @@ const Home: React.FC = () => {
     // Função para carregar as imagens do jogador
     const playerImagesLoad = () => {
       const image = new Image();
-      image.src = '/images/pokemonTilesetMap.png';
+      image.src = '/Images/pokemonTilesetMap.png';
       
       // Ouvindo o evento de carregamento da imagem antes de continuar
       image.onload = () => {
         imageRef.current = image; // Armazena a imagem na ref
     
         const playerDownImage = new Image();
-        playerDownImage.src = '/images/playerDown.png';
+        playerDownImage.src = '/Images/playerDown.png';
     
         const playerUpImage = new Image();
-        playerUpImage.src = '/images/playerUp.png';
+        playerUpImage.src = '/Images/playerUp.png';
     
         const playerLeftImage = new Image();
-        playerLeftImage.src = '/images/playerLeft.png';
+        playerLeftImage.src = '/Images/playerLeft.png';
     
         const playerRightImage = new Image();
-        playerRightImage.src = '/images/playerRight.png';
+        playerRightImage.src = '/Images/playerRight.png';
     
         // Espera todas as imagens carregarem
         Promise.all([


### PR DESCRIPTION
This pull request includes changes to correct the casing of image file paths in the `BattleScreen` and `Home` components to ensure consistency and avoid potential issues on case-sensitive file systems.

Changes in `BattleScreen` component:

* Updated image paths to use capitalized `Images` directory in `src` attribute for various images like `pokeball.gif`, 

Changes in `Home` component:

* Corrected image paths for player images and tileset map to use the capitalized `Images` directory. (`frontend/app/page.tsx`, 